### PR TITLE
Update/multi repo functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,176 @@
-# Git S3 Cache Buildkite Plugin
+# **Git S3 Cache Buildkite Plugin**
 
-Adds a `pre-checkout` hook that downloads a git mirror from S3 and uses it as part of the `checkout` process.
+Adds a `pre-checkout` hook that downloads git mirrors or bare repos from S3 and uses it as part of the `checkout` process.
+Can also clone the repos during `post-checkout` and clean them up in `pre-exit`.
 
-## Example
+- [**Git S3 Cache Buildkite Plugin**](#git-s3-cache-buildkite-plugin)
+  - [**Pipeline Usage**](#pipeline-usage)
+  - [**Configuration**](#configuration)
+  - [**Examples**](#examples)
+    - [Single Cached Repo](#single-cached-repo)
+    - [Two Cached Repos](#two-cached-repos)
+    - [Cache Primary Build Repo](#cache-primary-build-repo)
+    - [Cache Single Repo for Multiple Steps on Multiple Agents](#cache-single-repo-for-multiple-steps-on-multiple-agents)
+  - [**Developing**](#developing)
+  - [**Contributing**](#contributing)
+## **Pipeline Usage**
 
 Add the following to your `pipeline.yml`:
 
 ```yml
 steps:
-  - command:
-      - "yarn install"
-      - "yarn run test"
-    plugins:
-      - automattic/git-s3-cache#v1.0.0:
+  - command: <generic command>
+    label: "Caching Reference Repos"
+    plugin:
+      - automattic/git-s3-cache#v1.1.6:
           bucket: "my-s3-bucket"
-          repo: "path-to-repo-in-s3/" # note the trailing slash – it must be present
-```
+          repos: "repo-name or repo-names"
+          path: "path/to/repo"
+          git_clone_flags: false
+          auto_clone: true
+          github_url: "full://github/path/with_org"
+          auto_clean: true
 
-## Configuration
+```
+(*More examples below*)
+
+## **Configuration**
 
 Before using this plugin, you should have an S3 bucket set up in a format similar to:
 
 ```
 my-bucket/
 ├── my-project/
-│   ├── 2020-01-01-my-project.git
-│   ├── 2020-01-03-my-project.git
-│   ├── 2020-01-05-my-project.git
-```
-
-```
-my-bucket/
-├── my-project/
 │   ├── 2000-01-01
-│       ├── my-project.git
+│       ├── my-project.git.tar
 │   └── 2001-01-01
-│       ├── my-project.git
+│       ├── my-project.git.tar
 
 ```
+>**Repos must be in tar format (eg `tar -cf <filename>.tar <source>`).**
 
-Git mirrors must end in `.git`, and should be sorted alphabetically with the most recent mirror appearing last.
+Git mirrors/bare repositories must end in `.git`, and should be sorted alphabetically with the most recent mirror appearing last. For faster builds, we recommend **NOT** compressing your repos.
+<br><br>
 
-### `bucket` (Required, string)
 
-The S3 bucket containing your mirrors.
+Key | Required | Type | Description
+:---------|:----------:|:---------:|:---------
+`bucket` | **Required** | string | The S3 bucket containing your mirrors.
+`repos` | **Required** | string | Names of the repo or repo's you want to cache, separated by a space. Repos can include path info eg. `android/android.git`<p><p>**NOTE**: If you include path information, the plugin will automatically add the snapshot date in bewteen. (eg. `android/2021-07-08/android.git`).<p><p>*(This currently only supports one additional path. This will need to updated to handle unknown numbers of paths.)* <p>
+`path` | **Required** | string | The primary path in S3 to your repo(s).  For multi-repos, this should be common for them all
+`git_clone_flags` | Optional | booleans | Changes the behavior of the Buildkite Agent when it clones the build repo.<p><p> If specified to `true` this will alter the git clone functionality for the entire build to `-v --reference-if-able <reference_repo_destination>`.<p>*Works only with one repo and, should be your repo that is running the pipeline.*
+`auto-clone` | optional | boolean | If `true` will attempt to clone the repos you specified into the workspace. Set this to false if you want to control when and where your repos get cloned manually.<p><p>***Requires**:* complete `github_url` path to repo.
+`github_url` | optional | string | Needed for `auto-clone` functionality. Should be full path up to repo, do not include trailing slash.<p><p> *Should work with ssh links as well*.
+`auto-clean` | optional | boolean | If `true` it will delete the build directory in `/tmp/${BUILDKITE_PIPELINE_NAME}`. <p><p>Use for systems that are not ephemeral.<p><p>*This runs at the end of EVERY STEP in a pipeline. It is most helpful with parallel builds.*
 
-### `repo` (Required, string)
+## **Examples**
+<p><br><p>
 
-The S3 path to the repo. **Must include a trailing slash**.
+### Single Cached Repo
 
-## Developing
+ ```yml
+steps:
+  - command: test_repo.sh
+    label: "Caching Reference Repos"
+    plugin:
+      - automattic/git-s3-cache#v1.1.6:
+          bucket: "my-s3-bucket"
+          repos: "jetpack"
+          path: "wordpress"
+          git_clone_flags: false
+          auto_clone: true
+          github_url: "https://github.com/automattic"
+          auto_clean: true
+```
+
+- Cache `jetpack.git` from `s3://my-s3-bucket/wordpress/<latest_date>/`
+- Clone this repo into the build working directory
+- Run `test_repo.sh`
+- Delete the cached repo at the end of the step
+<p><br><p>
+
+### Two Cached Repos
+
+ ```yml
+steps:
+  - command: test_repo.sh
+    label: "Caching Reference Repos"
+    plugin:
+      - automattic/git-s3-cache#v1.1.6:
+          bucket: "my-s3-bucket"
+          repos: "jetpack/jetpack calypso/wp-calypso"
+          path: "wordpress"
+          git_clone_flags: false
+          auto_clone: true
+          github_url: "https://github.com/automattic"
+          auto_clean: true
+```
+
+- Assumes pipeline is running in a separate repo
+ (eg. github.com/wordpress/sensei)
+- Cache `jetpack.git` from `s3://my-s3-bucket/wordpress/jetpack/<latest_date>/`
+- Cache `wp-calypso.git` from `s3://my-s3-bucket/**wordpress**/calypso/<latest_date>/`
+- Clone both repos into the build working directory
+- Run `test_repo.sh`
+- Delete the cached repo at the end of the step
+<p><br><p>
+
+### Cache Primary Build Repo
+
+ ```yml
+steps:
+  - command: test_repo.sh
+    label: "Caching Reference Repo"
+    plugin:
+      - automattic/git-s3-cache#v1.1.6:
+          bucket: "my-s3-bucket"
+          repos: "jetpack"
+          path: "wordpress"
+          git_clone_flags: true
+          auto_clone: false
+          auto_clean: false
+```
+
+
+- Assumes pipeline is running in Jetpack repo (eg. github.com/wordpress/jetpack)
+- Cache `jetpack.git` from `s3://my-s3-bucket/wordpress/<latest_date>/`
+- During the `Preparing working directory` step, it will clone using the reference repo.
+- Run `test_repo.sh`
+- Leave the cached repo on agent
+<p><br><p>
+
+### Cache Single Repo for Multiple Steps on Multiple Agents
+
+```yml
+git-s3-cache: &git-s3-cache
+  plugin:
+    - automattic/git-s3-cache#v1.1.6:
+        bucket: "my-s3-bucket"
+        repos: "wp/jetpack"
+        path: "wordpress"
+        github_url: "https://github.com/automattic"
+        git_clone_flags: false
+        auto_clone: true
+        auto_clean: true
+
+  - label: "step 1"
+    <<: *git-s3-cache
+    command: <your command>
+  - label: "step 2"
+    <<: *git-s3-cache
+    command: <your command>
+```
+
+- Assumes pipeline is running in a separate repo
+ (eg. github.com/wordpress/sensei)
+- *Runs both steps concurrently on two available agents*
+- Cache `jetpack.git` from `s3://my-s3-bucket/wordpress/wp/jetpack/<latest_date>/`
+- Clone the repo into the build working directory
+- Run `<your command>`
+- Delete the cached repo from each agent at the end of the step
+<p><br><p>
+
+## **Developing**
 
 To run the tests:
 
@@ -57,7 +178,7 @@ To run the tests:
 docker-compose run --rm lint
 ```
 
-## Contributing
+## **Contributing**
 
 1. Fork the repo
 2. Make the changes

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -eo pipefail
+
+AUTO_CLONE="${BUILDKITE_PLUGIN_GIT_S3_CACHE_AUTO_CLONE:-"false"}"
+
+if [ $AUTO_CLONE = "true" ]; then
+  # create array of repos
+  IFS=' '
+  read -r -a REPOS <<< "$BUILDKITE_PLUGIN_GIT_S3_CACHE_REPOS"
+  GITHUB_URL="$BUILDKITE_PLUGIN_GIT_S3_CACHE_GITHUB_URL"
+
+  echo "--- :github: Auto-Cloning Reference Repos"
+
+  for repo in "${REPOS[@]}"; do
+    #  fix up if repos have prefix paths
+    if [[ $repo =~ "/" ]]; then
+      REPO_NAME=$(echo "$repo" | cut -d "/" -f 2)
+    else
+      REPO_NAME=$repo
+    fi
+
+    # Getting reference repo destinations
+    REPO_NAME_REFERENCE_DESTINATION=$(echo "$REPO_NAME" | tr '[:lower:]' '[:upper:]' | tr '-' '_')_REFERENCE_DESTINATION
+    echo "   :git: Now cloning ${REPO_NAME}"
+    git clone -v --reference-if-able ${!REPO_NAME_REFERENCE_DESTINATION} ${GITHUB_URL}/${REPO_NAME}.git
+  done
+else
+  echo "   Auto Cloning Disabled"
+fi

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -1,35 +1,91 @@
-#!/bin/bash
-set -euo pipefail
+#!/bin/bash​
+# do not set `u`, it will break due to line
+set -eo pipefail
 
-REPO_PATH="$BUILDKITE_PLUGIN_GIT_S3_CACHE_REPO"
+# create array of repos
+IFS=' '
+read -r -a REPOS <<< "$BUILDKITE_PLUGIN_GIT_S3_CACHE_REPOS"
+
 BUCKET="$BUILDKITE_PLUGIN_GIT_S3_CACHE_BUCKET"
+REPO_PATH="$BUILDKITE_PLUGIN_GIT_S3_CACHE_PATH"
+GIT_CLONE_FLAGS="${BUILDKITE_PLUGIN_GIT_S3_CACHE_GIT_CLONE_FLAGS:-"false"}"
 
-echo "--- 📦  Restoring cache for $REPO_PATH from $BUCKET"
+echo "--- :database: Restoring cache for job: $BUILDKITE_PIPELINE_SLUG"
 
-# Fetch the most recent S3 backup key
-SNAPSHOT_KEY=$(aws --output json s3api list-objects-v2 --bucket $BUCKET --prefix $REPO_PATH --query 'Contents[].Key' | jq -r '.[] | select(endswith(".git/"))' | sort -r | head -n1)
+for repo in "${REPOS[@]}"; do
+  echo "--- :sweating: Working on $repo..."
 
-# Exit early if there's no available snapshot
-if [ -z "$SNAPSHOT_KEY" ]; then
-	echo "No snapshots found in $BUCKET"
-	exit 0
+  # fix up if repos have prefix paths
+  if [[ $repo =~ "/" ]]; then
+    REPO_NAME=$(echo "$repo" | cut -d "/" -f 2)
+    REPO_PREFIX=$(echo "$repo" | cut -d "/" -f 1)
+    # Fetch the most recent S3 backup date and assemble paths
+    LATEST_SNAPSHOT_DATE=$(aws --output json s3api list-objects-v2 --bucket "$BUCKET" --prefix "$REPO_PATH" --query 'Contents[].Key' | jq -r '.[]' | grep "$REPO_NAME" | sort -r | head -1 | cut -d "/" -f 3)
+    LATEST_REPO_PATH="${BUCKET}/${REPO_PATH}/${REPO_PREFIX}/${LATEST_SNAPSHOT_DATE}/${REPO_NAME}.git.tar"
+  else
+    REPO_NAME=$repo
+    # Fetch the most recent S3 backup date and assemble paths
+    LATEST_SNAPSHOT_DATE=$(aws --output json s3api list-objects-v2 --bucket "$BUCKET" --prefix "$REPO_PATH" --query 'Contents[].Key' | jq -r '.[]' | grep "$REPO_NAME" | sort -r | head -1 | cut -d "/" -f 3)
+    LATEST_REPO_PATH="${BUCKET}/${REPO_PATH}/${LATEST_SNAPSHOT_DATE}/${REPO_NAME}.git.tar"
+  fi
+
+  # Check if there is actually contents in the assembled path and not just an empty dir.
+  REPO_CONTENTS=$(aws s3 ls s3://"$LATEST_REPO_PATH")
+  if [ -z "$REPO_CONTENTS" ]; then
+    echo "--- :bk-status-failed: Fatal Error! No data found in ${LATEST_REPO_PATH}! Perhaps the repo name is wrong?"
+    exit 1
+  else
+    echo "   ↳ ${REPO_NAME} Snapshot found! It is dated ${LATEST_SNAPSHOT_DATE}."
+  fi
+
+  # Destination is where we will copy to on the agent
+  DESTINATION="/tmp/$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_PIPELINE_ID"
+
+  echo "--- ↳ :file-cabinet: Downloading snapshot of [ $REPO_NAME ] from [ $LATEST_REPO_PATH ] to local path: [ $DESTINATION ]"
+
+  # Clear and then download!
+  rm -rf "$DESTINATION"
+  S3_SYNC_RESULT=$(aws s3 cp --acl private --sse aws:kms s3://"$LATEST_REPO_PATH" "$DESTINATION"/)
+  DOWNLOAD_STATUS=$?
+
+  # S3 directory commands can fail silently and still exit 0,
+  # so we ensure that there was actually something that happened
+  if [ $DOWNLOAD_STATUS = 0 ] && [ -n "$S3_SYNC_RESULT" ]; then
+    echo "   ↳ 🎉 Download complete!"
+  else
+    echo "--- :bk-status-failed: Fatal Error during download!"
+    echo "$S3_SYNC_RESULT"
+    exit 1
+  fi
+
+  # un-tar the file
+  echo "--- ↳ :scissors: Extracting ${REPO_NAME}"
+  tar -xf "$DESTINATION"/"$REPO_NAME".git.tar -C "$DESTINATION"/
+  UNTAR_RESULT=$?
+  if [ "$UNTAR_RESULT" != 0 ]; then
+    echo "--- :bk-status-failed: Failed to untar archive. Hopefully you are giving me some tar?"
+    echo "---   RESULT:  $UNTAR_RESULT"
+    exit 1
+  fi
+
+  # create ENV variable for pipeline use
+  REPO_NAME_ENV=$(echo "$REPO_NAME" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+  export "${REPO_NAME_ENV}_REFERENCE_DESTINATION"="$DESTINATION"/"$REPO_NAME".git
+  echo "   ↳ Exported: ${REPO_NAME_ENV}_REFERENCE_DESTINATION=$DESTINATION/${REPO_NAME}.git"
+
+  SIZE=$(du -sh "$DESTINATION"  | cut -f1 -d$'\t')
+  echo "--- :bk-status-passed: Restore of $repo Complete – Downloaded $SIZE"
+done
+
+# If specified, overwrite the clone flags to use reference repo
+# Will not work for multiple repos
+if [ -z ${REPOS[1]+x} ]; then
+  if [ "$GIT_CLONE_FLAGS" = true ]; then
+    export BUILDKITE_GIT_CLONE_FLAGS="-v --reference-if-able $DESTINATION"
+    echo "   ↳ Export of BUILDKITE_GIT_CLONE_FLAGS complete"
+  fi
+else
+  echo "   ↳ Unable to set BUILDKITE_GIT_CLONE_FLAGS since multiple repos were specified. No need for this flag if specifying multiple repos."
 fi
 
-echo "Downloading snapshot: $SNAPSHOT_KEY"
-
-DESTINATION="/tmp/$BUILDKITE_PIPELINE_SLUG.git"
-
-# Then download it
-aws s3 cp --recursive "s3://$BUCKET/$SNAPSHOT_KEY" "$DESTINATION"
-
-SIZE=$(du -sh $DESTINATION  | cut -f1 -d$'\t')
-
-echo "Restore Complete – Downloaded $SIZE"
-
-cd $DESTINATION
-pwd
-ls
-cd -
-
-# Overwrite the clone flags to use the reference
-export BUILDKITE_GIT_CLONE_FLAGS="-v --reference $DESTINATION"
+echo "--- :bk-status-passed: Restore of All Reference Repos Complete"

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -1,5 +1,5 @@
 #!/bin/bash​
-# do not set `u`, it will break due to line
+# do not set `u`, it will break this script
 set -eo pipefail
 
 # create array of repos

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Cleanup
+
+AUTO_CLEAN="${BUILDKITE_PLUGIN_GIT_S3_CACHE_AUTO_CLEAN:-"false"}"
+
+if [ "$AUTO_CLEAN" = "true" ]; then
+
+  echo "--- :broom: Auto-Clean is ON! Deleting references repos as requested. "
+  rm -rf /tmp/"$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_PIPELINE_ID"/
+else
+  echo "   ↳ Auto-Cleanup is disabled."
+fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,11 +1,21 @@
 name: Git S3 Cache
-description: Reads your git repo from an S3 cache
+description: Reads and clones your git repo from an S3 cache
 author: https://github.com/automattic
 requirements: []
 configuration:
   properties:
-    repo:
+    repos:
       type: string
     bucket:
       type: string
+    path:
+      type: string
+    github_url:
+      type: string
+    git_clone_flags:
+      type: boolean
+    auto_clone:
+      type: boolean
+    auto_clean:
+      type: boolean
   additionalProperties: false


### PR DESCRIPTION
This adds in functionality to cache and clone multiple repos from S3 into a build's working directory.  It also allows for the primary repo to be cloned via a local reference repo as in version 1. 

Major changes:
 - The s3 repo's have to be organized in a specific way and the bare/mirror repo needs to be compressed as a tar file (eg: s3://bucket-name/<LATEST DATE>/repo.git.tar). 
 - Can now handle caching multiple repos
 - Can now clone cached repos into your working directory
 - Can now automatically delete cached repo data at the end of each step (pre-exit)

All changes are found in the updated documentation. 