### PR TITLE
Add vm host support

### DIFF
--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -15,7 +15,7 @@ BUCKET="$BUILDKITE_PLUGIN_GIT_S3_CACHE_BUCKET"
 echo "--- 📦  Restoring cache for $REPO_PATH from $BUCKET"
 
 # Fetch the most recent S3 backup key
-SNAPSHOT_KEY=$(aws --output json s3api list-objects-v2 --bucket $BUCKET --prefix $REPO_PATH --query 'Contents[].Key' | jq -r '.[] | select(endswith(".git/"))' | sort -r | head -n1)
+SNAPSHOT_KEY=$(aws --output json s3api list-objects-v2 --bucket $BUCKET --prefix $REPO_PATH --query 'Contents[].Key' | jq -r '.[] | select(endswith(".git.tar"))' | sort -r | head -n1)
 
 # Exit early if there's no available snapshot
 if [ -z "$SNAPSHOT_KEY" ]; then
@@ -23,21 +23,22 @@ if [ -z "$SNAPSHOT_KEY" ]; then
 	exit 0
 fi
 
-echo "Downloading snapshot: $SNAPSHOT_KEY"
-
-DESTINATION="/tmp/$BUILDKITE_PIPELINE_SLUG.git"
+DESTINATION=/tmp/$BUILDKITE_PIPELINE_SLUG.git.tar
+echo "Downloading snapshot: $SNAPSHOT_KEY to $DESTINATION"
 
 # Then download it
-aws s3 cp --recursive "s3://$BUCKET/$SNAPSHOT_KEY" "$DESTINATION"
+rm -rf $DESTINATION # Delete before starting, just in case
+aws s3 cp "s3://$BUCKET/$SNAPSHOT_KEY" "$DESTINATION"
 
 SIZE=$(du -sh $DESTINATION  | cut -f1 -d$'\t')
 
-echo "Restore Complete – Downloaded $SIZE"
+echo "Downloaded $SIZE"
 
-cd $DESTINATION
-pwd
-ls
-cd -
+REFERENCE_REPO="/tmp/$BUILDKITE_PIPELINE_SLUG.git"
+
+echo "Decompressing $DESTINATION to $REFERENCE_REPO"
+tar -xf $DESTINATION -C /tmp
+rm $DESTINATION
 
 # Overwrite the clone flags to use the reference
-export BUILDKITE_GIT_CLONE_FLAGS="-v --reference $DESTINATION"
+export BUILDKITE_GIT_CLONE_FLAGS="-v --reference $REFERENCE_REPO"

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -22,7 +22,7 @@ if [ -n "${GIT_MIRROR_SERVER_ROOT:-}" ]; then
 	URL=$(curl "$GIT_MIRROR_SERVER_ROOT/manifest" | grep $REPO_PATH)
 
 	echo "Downloading snapshot $URL to $DESTINATION"
-	curl -so $DESTINATION "$GIT_MIRROR_SERVER_ROOT/$URL"
+	curl -so "$DESTINATION" "$GIT_MIRROR_SERVER_ROOT/$URL"
 # Otherwise, use S3 directly
 else
 	# Fetch the most recent S3 backup key

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -1,5 +1,13 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
+
+if [ -n "${IS_VM_HOST-}" ]; then
+	echo "VM Host variable set"
+	if [ $IS_VM_HOST ]; then 
+		echo "Is VM Host – exiting"
+		exit 0
+	fi
+fi
 
 REPO_PATH="$BUILDKITE_PLUGIN_GIT_S3_CACHE_REPO"
 BUCKET="$BUILDKITE_PLUGIN_GIT_S3_CACHE_BUCKET"

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -14,21 +14,32 @@ BUCKET="$BUILDKITE_PLUGIN_GIT_S3_CACHE_BUCKET"
 
 echo "--- 📦  Restoring cache for $REPO_PATH from $BUCKET"
 
-# Fetch the most recent S3 backup key
-SNAPSHOT_KEY=$(aws --output json s3api list-objects-v2 --bucket $BUCKET --prefix $REPO_PATH --query 'Contents[].Key' | jq -r '.[] | select(endswith(".git.tar"))' | sort -r | head -n1)
-
-# Exit early if there's no available snapshot
-if [ -z "$SNAPSHOT_KEY" ]; then
-	echo "No snapshots found in $BUCKET"
-	exit 0
-fi
-
 DESTINATION=/tmp/$BUILDKITE_PIPELINE_SLUG.git.tar
-echo "Downloading snapshot: $SNAPSHOT_KEY to $DESTINATION"
 
-# Then download it
-rm -rf $DESTINATION # Delete before starting, just in case
-aws s3 cp "s3://$BUCKET/$SNAPSHOT_KEY" "$DESTINATION"
+# If we have an available Git Mirror Server, use it
+if [ -n "${GIT_MIRROR_SERVER_ROOT:-}" ]; then
+	echo "Using Git Mirror Server at $GIT_MIRROR_SERVER_ROOT"
+	URL=$(curl "$GIT_MIRROR_SERVER_ROOT/manifest" | grep $REPO_PATH)
+
+	echo "Downloading snapshot $URL to $DESTINATION"
+	curl -so $DESTINATION "$GIT_MIRROR_SERVER_ROOT/$URL"
+# Otherwise, use S3 directly
+else
+	# Fetch the most recent S3 backup key
+	SNAPSHOT_KEY=$(aws --output json s3api list-objects-v2 --bucket $BUCKET --prefix $REPO_PATH --query 'Contents[].Key' | jq -r '.[] | select(endswith(".git.tar"))' | sort -r | head -n1)
+
+	# Exit early if there's no available snapshot
+	if [ -z "$SNAPSHOT_KEY" ]; then
+		echo "No snapshots found in $BUCKET"
+		exit 0
+	fi
+
+	echo "Downloading snapshot: $SNAPSHOT_KEY to $DESTINATION"
+
+	# Then download it
+	rm -rf $DESTINATION # Delete before starting, just in case
+	aws s3 cp "s3://$BUCKET/$SNAPSHOT_KEY" "$DESTINATION"
+fi
 
 SIZE=$(du -sh $DESTINATION  | cut -f1 -d$'\t')
 
@@ -39,6 +50,9 @@ REFERENCE_REPO="/tmp/$BUILDKITE_PIPELINE_SLUG.git"
 echo "Decompressing $DESTINATION to $REFERENCE_REPO"
 tar -xf $DESTINATION -C /tmp
 rm $DESTINATION
+
+ls /tmp
+ls $REFERENCE_REPO
 
 # Overwrite the clone flags to use the reference
 export BUILDKITE_GIT_CLONE_FLAGS="-v --reference $REFERENCE_REPO"


### PR DESCRIPTION
This PR adds support for macOS VM hosts – if there is a URL available for a VM host, the plugin will try to use its cache to download the repo mirror.

**To Test**
- See that https://github.com/wordpress-mobile/WordPress-iOS/pull/16787 is passing in Buildkite, and that the checkout takes only ~8 seconds – this indicates that it's working (there's some helpful info in the log as well).