### PR TITLE
Fix S3 XFer Race Condition

### DIFF
--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -103,9 +103,6 @@ if [ -n "${GIT_MIRROR_SERVER_ROOT:-}" ]; then
       echo "--- :warning: S3 Download failed. This probably means the cache may not exist yet."
       echo "  ↳ Full error: $S3_XFER_STATUS"
       ERRORS_ARRAY+=("- S3 Download failed as well. Cache may not exist yet.  Full error: $S3_XFER_STATUS ")
-      if [ -n "${ERRORS_ARRAY[*]}" ]; then
-        annotate_error "${ERRORS_ARRAY[@]}"
-      fi
       exit 0
     fi
   fi
@@ -115,11 +112,11 @@ else
     echo "--- :warning: S3 Download failed. This probably means the cache may not exist yet."
     echo "  ↳ Full error: $S3_XFER_STATUS"
     ERRORS_ARRAY+=("- S3 Download failed as well. Cache may not exist yet.  Full error: $S3_XFER_STATUS ")
-    if [ -n "${ERRORS_ARRAY[*]}" ]; then
-      annotate_error "${ERRORS_ARRAY[@]}"
-    fi
-    exit 0
   fi
+fi
+
+if [ -n "${ERRORS_ARRAY[*]}" ]; then
+  annotate_error "${ERRORS_ARRAY[@]}"
 fi
 
 SIZE=$(du -sh "$DESTINATION"  | cut -f1 -d$'\t')

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -24,7 +24,7 @@ git_mirror_download () {
     curl -so "$DESTINATION" "$GIT_MIRROR_SERVER_ROOT/$URL"
     MIRROR_XFER_STATUS=$?
     if [ $MIRROR_XFER_STATUS == 0 ]; then
-      echo ":large_green_circle: Cache download successful!"
+      echo "~~~ :large_green_circle: Cache download successful!"
       return 0
     else
       # we failed, exit
@@ -53,10 +53,10 @@ s3_download () {
     echo "Downloading snapshot: $SNAPSHOT_KEY to $DESTINATION"
     # Then download it
     rm -rf "$DESTINATION" # Delete before starting, just in case
-    aws s3 cp "s3://$BUCKET/$SNAPSHOT_KEY" "$DESTINATION"
+    aws s3 cp "s3://$BUCKET/$SNAPSHOT_KEY" "$DESTINATION" --no-progress
     S3_XFER_STATUS=$?
     if [ $S3_XFER_STATUS == 0 ]; then
-      echo ":large_green_circle: S3 Download Succeeded"
+      echo "~~~ :large_green_circle: S3 Download Succeeded"
       return 0
     else
       # s3 download failed, error message is below.
@@ -95,9 +95,9 @@ ${ERRORS}
 
 # If we have an available Git Mirror Server, use it
 if [ -n "${GIT_MIRROR_SERVER_ROOT:-}" ]; then
-  echo "Git mirror found, attempting download."
+  echo "~~~ Git mirror found, attempting download."
   if ! git_mirror_download; then
-    echo "~~~ :warning: Git Mirror download failed, attempting download from s3."
+    echo "~~~ :warning: Git Mirror download failed, attempting download from s3...."
     ERRORS_ARRAY+=("- Git Mirror download failed, attempting download from s3.")
     if ! s3_download; then
       echo "--- :warning: S3 Download failed. This probably means the cache may not exist yet."

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -91,6 +91,12 @@ ${ERRORS}
 "
 }
 
+annotate() {
+  if [ -n "${ERRORS_ARRAY[*]}" ]; then
+    annotate_error "${ERRORS_ARRAY[@]}"
+  fi
+}
+
 ###### BEGIN ######
 
 # If we have an available Git Mirror Server, use it
@@ -103,6 +109,7 @@ if [ -n "${GIT_MIRROR_SERVER_ROOT:-}" ]; then
       echo "--- :warning: S3 Download failed. This probably means the cache may not exist yet."
       echo "  ↳ Full error: $S3_XFER_STATUS"
       ERRORS_ARRAY+=("- S3 Download failed as well. Cache may not exist yet.  Full error: $S3_XFER_STATUS ")
+      annotate
       exit 0
     fi
   fi
@@ -112,12 +119,12 @@ else
     echo "--- :warning: S3 Download failed. This probably means the cache may not exist yet."
     echo "  ↳ Full error: $S3_XFER_STATUS"
     ERRORS_ARRAY+=("- S3 Download failed as well. Cache may not exist yet.  Full error: $S3_XFER_STATUS ")
+    annotate
+    exit 0
   fi
 fi
 
-if [ -n "${ERRORS_ARRAY[*]}" ]; then
-  annotate_error "${ERRORS_ARRAY[@]}"
-fi
+annotate
 
 SIZE=$(du -sh "$DESTINATION"  | cut -f1 -d$'\t')
 

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -22,8 +22,14 @@ git_mirror_download () {
   if URL=$(curl "$GIT_MIRROR_SERVER_ROOT/manifest" | grep $REPO_PATH$); then
     echo "Downloading snapshot $URL to $DESTINATION"
     curl -so "$DESTINATION" "$GIT_MIRROR_SERVER_ROOT/$URL"
-    echo ":large_green_circle: Cache download successful!"
-    return 0
+    MIRROR_XFER_STATUS=$?
+    if [ $MIRROR_XFER_STATUS == 0 ]; then
+      echo ":large_green_circle: Cache download successful!"
+      return 0
+    else
+      # we failed, exit
+      return 2
+    fi
   else
     echo "  ↳ WARNING: No snapshots found in $GIT_MIRROR_SERVER_ROOT. Will attempt s3."
     ERRORS_ARRAY+=("- WARNING: No snapshots found in $GIT_MIRROR_SERVER_ROOT. Will attempt s3.")
@@ -47,8 +53,9 @@ s3_download () {
     echo "Downloading snapshot: $SNAPSHOT_KEY to $DESTINATION"
     # Then download it
     rm -rf "$DESTINATION" # Delete before starting, just in case
-    S3_XFER_STATUS=$(aws s3 cp "s3://$BUCKET/$SNAPSHOT_KEY" "$DESTINATION")
-    if $S3_XFER_STATUS; then
+    aws s3 cp "s3://$BUCKET/$SNAPSHOT_KEY" "$DESTINATION"
+    S3_XFER_STATUS=$?
+    if [ $S3_XFER_STATUS == 0 ]; then
       echo ":large_green_circle: S3 Download Succeeded"
       return 0
     else
@@ -122,7 +129,7 @@ echo "Downloaded $SIZE"
 REFERENCE_REPO="/tmp/$BUILDKITE_PIPELINE_SLUG.git"
 
 echo "Decompressing $DESTINATION to $REFERENCE_REPO"
-tar -xf $DESTINATION -C /tmp
+tar -xf "$DESTINATION" -C /tmp
 rm "$DESTINATION"
 
 ls /tmp


### PR DESCRIPTION
On one final test, I noticed that the changes for creating the variable `S3_XFER_STATUS` with the command to download from S3 did not stop the script until it completed and it would then fail because it didn't know if a download happened.  

[View the log here](https://buildkite.com/wordpress-mobile/tumblr-orangina/builds/55#986ff84b-a728-475c-bfd5-86fc71d0f766)

This fixes that issue as well as cleans up a bit of the logging. It also ensures that if any errors happen they will be annotated regardless of downloads being successful. 

Also the `--no-quiet` flag was add to the s3 download to prevent the Truncation Warnings that were happening in BK logs.

