### PR TITLE
Fix an issue with the S3 snapshot key check

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The S3 bucket containing your mirrors.
 
 ### `repo` (Required, string)
 
-The S3 path to the repo. **Must include a trailing slash**.
+The S3 path to the repo. For example `my-org/my-project`.
 
 ## Developing
 

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -9,7 +9,9 @@ if [ -n "${IS_VM_HOST-}" ]; then
   fi
 fi
 
-REPO_PATH="$BUILDKITE_PLUGIN_GIT_S3_CACHE_REPO"
+# Extract the plugin's configuration properties
+# For `repo:`, make sure we have it end with a `/` (removing trailing slash if present, then re-adding one explicitly)
+REPO_PATH="${BUILDKITE_PLUGIN_GIT_S3_CACHE_REPO%/}"/
 BUCKET="$BUILDKITE_PLUGIN_GIT_S3_CACHE_BUCKET"
 ERRORS_ARRAY=()
 
@@ -48,8 +50,10 @@ s3_download () {
     return 1
   fi
 
+ # Extract the first 2 components of the key, then compare it with the provided `REPO_PATH` (which ends with a `/`)
+ # Note that the `SNAPSHOT_KEY` can follow either the `<bucket>/<project>/<date>.git.tar` or `<bucket>/<project>/<date>/<project.git.tar` structure
  SNAPSHOT_KEY_CHECK=$(echo "$SNAPSHOT_KEY" | cut -d "/" -f 1-2)
-  if [ "$SNAPSHOT_KEY_CHECK" == "$REPO_PATH" ]; then
+  if [ "${SNAPSHOT_KEY_CHECK}/" == "${REPO_PATH}" ]; then
     echo "Downloading snapshot: $SNAPSHOT_KEY to $DESTINATION"
     # Then download it
     rm -rf "$DESTINATION" # Delete before starting, just in case


### PR DESCRIPTION
See issue reported in 50-gh-Automattic/pocket-casts-ios

## Why?

`REPO_PATH` is expected to end with a trailing slash, but `SNAPSHOT_KEY_CHECK=$(echo "$SNAPSHOT_KEY" | cut -d "/" -f 1-2)` doesn't contain a trailing slash. So when comparing the two, the `if` always fails.

I'm not sure how/why it seems to have been working fine for other repos so far (like WPiOS) but only failed for our PocketCast repo… but at least this change should make the hook more resilient.

## How

 - Make the code ensure that `REPO_PATH` ends with a `/` even if the user of the plugin didn't end the `repo:` configuration property with a `/` at usage site.
 - Update the `if` test that is checking the `SNAPSHOT_KEY` match in the S3 case, to include the trailing `/` in that comparison.

## To Test

 - Point a new repo which encountered that issue, like 50-gh-Automattic/pocket-casts-ios, to this PR's branch
 - Run the pipeline in that client repo using the plugin
 - Ensure that the cache is found