### PR TITLE
Add shellcheck

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,5 @@
+steps:
+  - label: ":shell: Lint (Shellcheck)"
+    plugins:
+      shellcheck#v1.2.0:
+        files: ["hooks/**"]

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -19,7 +19,7 @@ DESTINATION=/tmp/$BUILDKITE_PIPELINE_SLUG.git.tar
 
 git_mirror_download () {
   echo "Using Git Mirror Server at $GIT_MIRROR_SERVER_ROOT"
-  if URL=$(curl "$GIT_MIRROR_SERVER_ROOT/manifest" | grep $REPO_PATH$); then
+  if URL=$(curl "$GIT_MIRROR_SERVER_ROOT/manifest" | grep "$REPO_PATH"$); then
     echo "Downloading snapshot $URL to $DESTINATION"
     curl -so "$DESTINATION" "$GIT_MIRROR_SERVER_ROOT/$URL"
     MIRROR_XFER_STATUS=$?


### PR DESCRIPTION
What it says on the tin.

Ensures the `pre-checkout` script follows code style and more importantly, doesn't contain accidental syntax/logic errors or fall into subtle bash traps.

### To Test

 - I expect the first CI runs to find and report lint warnings (at least a warning `SC2086` on line 22 like I have when running it locally), which would be a good check to ensure that lint step works and the CI check fails as expected.
 - Once we confirmed the warning is reported, we can fix it, push the fix, and validate the build and CI check passes