### PR TITLE
Do not annotate pipeline with "missing repo" warning

### DIFF
--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -34,7 +34,6 @@ git_mirror_download () {
     fi
   else
     echo "  ↳ WARNING: No snapshots found in $GIT_MIRROR_SERVER_ROOT. Will attempt s3."
-    ERRORS_ARRAY+=("- WARNING: No snapshots found in $GIT_MIRROR_SERVER_ROOT. Will attempt s3.")
     return 1
   fi
 }
@@ -108,7 +107,6 @@ if [ -n "${GIT_MIRROR_SERVER_ROOT:-}" ]; then
   echo "~~~ Git mirror found, attempting download."
   if ! git_mirror_download; then
     echo "~~~ :warning: Git Mirror download failed, attempting download from s3...."
-    ERRORS_ARRAY+=("- Git Mirror download failed, attempting download from s3.")
     if ! s3_download; then
       echo "--- :warning: S3 Download failed. This probably means the cache may not exist yet."
       echo "  ↳ Full error: $S3_XFER_STATUS"


### PR DESCRIPTION
In testing #6, I noticed that the plugin now annotates the pipeline with warnings about missing repository in the given local Git server.

Example [this WordPress iOS build](https://buildkite.com/automattic/wordpress-ios/builds/8890#0182006a-2fba-4be6-953f-40a22a7fda9d) and [this Pocket Casts iOS build](https://buildkite.com/automattic/pocket-casts-ios/builds/38)

![image](https://user-images.githubusercontent.com/1218433/179164861-0b5dd108-9548-4b31-bf63-fb7379f55968.png)

![pcios](https://user-images.githubusercontent.com/1218433/178975149-e0e70cc9-534c-43b4-abd2-f8fe735311d2.png)

This PR removes the code that added those warnings to the array of messages to be annotated in the build. However, I wonder if we should fix the issue with the repo not being found in the first place instead 🤔 

I'm not too familiar with this plugin and the rationale behind how it works. @jkmassel @skoonin, any ideas or pointers on how to get started with this?