### PR TITLE
Fix plugin never finding the cached repo in the local Git cache server

### DIFF
--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -21,7 +21,18 @@ DESTINATION=/tmp/$BUILDKITE_PIPELINE_SLUG.git.tar
 
 git_mirror_download () {
   echo "Using Git Mirror Server at $GIT_MIRROR_SERVER_ROOT"
-  if URL=$(curl "$GIT_MIRROR_SERVER_ROOT/manifest" | grep "$REPO_PATH"$); then
+  # The manifest file has each cached repo on a line, in the org/name/id
+  # format.
+  #
+  # E.g.:
+  #
+  #   automattic/pocket-casts-ios/2022-07-16.git.tar
+  #   automattic/tumblr-ios/2022-07-16.git.tar
+  #   ...
+  #
+  # To find the path for the current repo, we `grep` for its name at the start
+  # of the line, using `^`.
+  if URL=$(curl "$GIT_MIRROR_SERVER_ROOT/manifest" | grep ^"$REPO_PATH"); then
     echo "Downloading snapshot $URL to $DESTINATION"
     curl -so "$DESTINATION" "$GIT_MIRROR_SERVER_ROOT/$URL"
     MIRROR_XFER_STATUS=$?


### PR DESCRIPTION
When I went to verify the S3 lookup fix from 14a974b7d0113d0518743b00cb2213de6ca431e9, I noticed new warning    annotations in the Buildkite builds. See https://github.com/Automattic/git-s3-cache-buildkite-plugin/pull/6#pullrequestreview-1038735114 and https://buildkite.com/automattic/wordpress-ios/builds/8890#0182006a-2fba-4be6-953f-40a22a7fda9d

<img width="1194" alt="image" src="https://user-images.githubusercontent.com/1218433/179662695-a2b4deb3-25b0-4a41-8816-294ba6747f1f.png">

    
After some `echo`-based debugging, I realized the warning was legit in that the `pre-checkout` code couldn't find the repo in the `manifest` file from the Git cache server when grepping for it.
    
The reason for the `grep` failure was that we were looking for the repo name at the end of the line (`$`) but the `manifest` file format has it at the start (`^`). See logs in the following build: https://buildkite.com/automattic/wordpress-ios/builds/8936#01821475-1daf-4f08-91dc-525da9517ae2/231-234

<img width="652" alt="image" src="https://user-images.githubusercontent.com/1218433/179662664-facb1fd5-ab40-42a1-bc00-aa11f51e6938.png">

This behavior was introduced in e95a4f30b248ff948b3b896ae482200edd06fc51, but went unnoticed at the time. In all this time, we never noticed because the warning annotation appeared in the WordPress iOS pipeline only after the work from 14a974b7d0113d0518743b00cb2213de6ca431e9, although I'm not sure why.

As a nice side effect, the builds are now ~1m faster because they can use the local cache server instead of downloading from S3 every time 🏃‍♂️ 

<img width="1661" alt="Screen Shot 2022-07-19 at 1 25 00 pm" src="https://user-images.githubusercontent.com/1218433/179663081-0fe33726-f232-450d-a06f-a1729d0c9cce.png">