### PR TITLE
Use the first match in the git mirror manifest file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ my-bucket/
 ├── my-project/
 │   ├── 2000-01-01
 │       ├── my-project.git
-│   └── 2001-01-01
+│   └── 2001-01-02
 │       ├── my-project.git
 
 ```

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -32,7 +32,7 @@ git_mirror_download () {
   #
   # To find the path for the current repo, we `grep` for its name at the start
   # of the line, using `^`.
-  if URL=$(curl "$GIT_MIRROR_SERVER_ROOT/manifest" | grep ^"$REPO_PATH"); then
+  if URL=$(curl "$GIT_MIRROR_SERVER_ROOT/manifest" | grep ^"$REPO_PATH" | head -n1); then
     echo "Downloading snapshot $URL to $DESTINATION"
     curl -so "$DESTINATION" "$GIT_MIRROR_SERVER_ROOT/$URL"
     MIRROR_XFER_STATUS=$?

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -31,8 +31,10 @@ git_mirror_download () {
   #   ...
   #
   # To find the path for the current repo, we `grep` for its name at the start
-  # of the line, using `^`.
-  if URL=$(curl "$GIT_MIRROR_SERVER_ROOT/manifest" | grep ^"$REPO_PATH" | head -n1); then
+  # of the line, using `^`. Similar to looking up the S3 bucket, the entries in
+  # the manifest are reverse sorted (as they should contain a date string after
+  # the `REPO_PATH`) so that the most recent cache gets downloaded.
+  if URL=$(curl "$GIT_MIRROR_SERVER_ROOT/manifest" | grep ^"$REPO_PATH" | sort -r | head -n1); then
     echo "Downloading snapshot $URL to $DESTINATION"
     curl -so "$DESTINATION" "$GIT_MIRROR_SERVER_ROOT/$URL"
     MIRROR_XFER_STATUS=$?


### PR DESCRIPTION
The original implementation assumes there is only one entry (supposedly the most recent one) for the repo key in the manifest file—the `URL` would not be an URL if there are multiple entries. This change removes the assumption and only greps the first line that starts with the repo key, so that this plugin would still work even if the manifest file contains multiple entries for the same key.

Even though this plugin uses the `/manifest` endpoint at the git mirror server, how the manifest file should be generated is not documented anyway, so I guess we probably should add a script to do that here (like the one mentioned in https://github.com/Automattic/hostmgr/pull/56#discussion_r1152514203)?